### PR TITLE
Explicitly set the domain in all set-cookie responses

### DIFF
--- a/.changeset/fifty-singers-applaud.md
+++ b/.changeset/fifty-singers-applaud.md
@@ -1,0 +1,5 @@
+---
+'@wanews/lambda-edge-openid-auth': patch
+---
+
+Explicity set the domain in set-cookie responses, and ensure secure: true

--- a/.changeset/many-eyes-rescue.md
+++ b/.changeset/many-eyes-rescue.md
@@ -1,0 +1,5 @@
+---
+'@wanews/lambda-edge-openid-auth': patch
+---
+
+clear cookies in 400 error page

--- a/libs/lambda-edge-openid-auth/src/lib/config.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/config.ts
@@ -31,6 +31,7 @@ export interface Config {
     logoutPath: string
     loginPath: string
     publicUrl: string
+    domain: string
     redirectUri: string
     postLogoutRedirectUri: string
 }
@@ -53,6 +54,7 @@ export function getConfig(
             logoutPath: '/logout',
             loginPath: '/login',
             publicUrl,
+            domain: request.headers.host[0].value,
             redirectUri: `${publicUrl}${callbackPath}`,
             postLogoutRedirectUri: `${publicUrl}${logoutCompletePath}`,
         },

--- a/libs/lambda-edge-openid-auth/src/lib/handlers/callback.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/handlers/callback.ts
@@ -147,6 +147,7 @@ export async function callbackHandler(
                             parsedTokenResponse.id_token,
                             {
                                 path: '/',
+                                secure: true,
                                 domain: config.domain,
                                 expires: decoded.exp
                                     ? new Date(decoded.exp * 1000)

--- a/libs/lambda-edge-openid-auth/src/lib/handlers/callback.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/handlers/callback.ts
@@ -32,7 +32,7 @@ export async function callbackHandler(
     // Check for error response (https://tools.ietf.org/html/rfc6749#section-4.2.2.1)
     if (queryDict.error) {
         if (Array.isArray(queryDict.error)) {
-            return badRequest()
+            return badRequest(config)
         }
         const error = IDP_ERRORS[queryDict.error] || queryDict.error
 
@@ -60,7 +60,7 @@ export async function callbackHandler(
     // Verify state in querystring is a string
     if (!queryDict.state || typeof queryDict.state !== 'string') {
         log.warn({ state: queryDict.state }, 'invalid state')
-        return badRequest()
+        return badRequest(config)
     }
 
     // Exchange code for authorization token
@@ -88,7 +88,7 @@ export async function callbackHandler(
             },
             'Token exchange failed',
         )
-        return badRequest()
+        return badRequest(config)
     }
     const parsedTokenResponse: any = await tokenResponse.json()
 
@@ -99,7 +99,7 @@ export async function callbackHandler(
 
     if (!decodedData || !decodedData.header.kid) {
         log.warn({ res: parsedTokenResponse }, 'Missing data')
-        return badRequest()
+        return badRequest(config)
     }
 
     log.info('Searching for JWK from discovery document')
@@ -120,7 +120,7 @@ export async function callbackHandler(
                 { payload: decoded },
                 'Failed to verify JWT, returned value is string',
             )
-            return badRequest()
+            return badRequest(config)
         }
 
         if (!nonce || !validateNonce(decoded.nonce, nonce)) {

--- a/libs/lambda-edge-openid-auth/src/lib/handlers/callback.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/handlers/callback.ts
@@ -49,12 +49,12 @@ export async function callbackHandler(
             error_uri = queryDict.error_uri
         }
 
-        return unauthorized(error, error_description, error_uri)
+        return unauthorized(config, error, error_description, error_uri)
     }
 
     // Verify code is in querystring
     if (!queryDict.code) {
-        return unauthorized('No Code Found', '', '')
+        return unauthorized(config, 'No Code Found', '', '')
     }
 
     // Verify state in querystring is a string
@@ -106,7 +106,7 @@ export async function callbackHandler(
     const pem = idpConfig.keyIdLookup[decodedData.header.kid]
     if (!pem) {
         log.warn({ kid: decodedData.header.kid }, 'Missing pem')
-        return unauthorized('Unknown kid', '', '')
+        return unauthorized(config, 'Unknown kid', '', '')
     }
 
     try {
@@ -124,7 +124,7 @@ export async function callbackHandler(
         }
 
         if (!nonce || !validateNonce(decoded.nonce, nonce)) {
-            return unauthorized('Nonce Verification Failed', '', '')
+            return unauthorized(config, 'Nonce Verification Failed', '', '')
         }
 
         // Once verified, create new JWT for this server
@@ -147,6 +147,7 @@ export async function callbackHandler(
                             parsedTokenResponse.id_token,
                             {
                                 path: '/',
+                                domain: config.domain,
                                 expires: decoded.exp
                                     ? new Date(decoded.exp * 1000)
                                     : undefined,
@@ -157,6 +158,7 @@ export async function callbackHandler(
                         key: 'Set-Cookie',
                         value: cookie.serialize('NONCE', '', {
                             path: '/',
+                            domain: config.domain,
                             expires: new Date(1970, 1, 1, 0, 0, 0, 0),
                         }),
                     },
@@ -170,10 +172,16 @@ export async function callbackHandler(
                 return redirect(config, idpConfig, request)
             case 'JsonWebTokenError':
                 log.info({ err }, 'JWT error, unauthorized.')
-                return unauthorized('Json Web Token Error', err.message, '')
+                return unauthorized(
+                    config,
+                    'Json Web Token Error',
+                    err.message,
+                    '',
+                )
             default:
                 log.info('Unknown JWT error, unauthorized.')
                 return unauthorized(
+                    config,
                     'Unknown JWT',
                     `User ${decodedData.payload.email} is not permitted.`,
                     '',

--- a/libs/lambda-edge-openid-auth/src/lib/handlers/logout-complete.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/handlers/logout-complete.ts
@@ -18,6 +18,7 @@ export function logoutCompleteHandler(config: Config) {
                     key: 'Set-Cookie',
                     value: cookie.serialize('IDP', '', {
                         path: '/',
+                        secure: true,
                         domain: config.domain,
                         httpOnly: true,
                     }),
@@ -26,6 +27,7 @@ export function logoutCompleteHandler(config: Config) {
                     key: 'Set-Cookie',
                     value: cookie.serialize('TOKEN', '', {
                         path: '/',
+                        secure: true,
                         domain: config.domain,
                         expires: new Date(1970, 1, 1, 0, 0, 0, 0),
                     }),
@@ -34,6 +36,7 @@ export function logoutCompleteHandler(config: Config) {
                     key: 'Set-Cookie',
                     value: cookie.serialize('NONCE', '', {
                         path: '/',
+                        secure: true,
                         domain: config.domain,
                         httpOnly: true,
                     }),

--- a/libs/lambda-edge-openid-auth/src/lib/handlers/logout-complete.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/handlers/logout-complete.ts
@@ -18,6 +18,7 @@ export function logoutCompleteHandler(config: Config) {
                     key: 'Set-Cookie',
                     value: cookie.serialize('IDP', '', {
                         path: '/',
+                        domain: config.domain,
                         httpOnly: true,
                     }),
                 },
@@ -25,6 +26,7 @@ export function logoutCompleteHandler(config: Config) {
                     key: 'Set-Cookie',
                     value: cookie.serialize('TOKEN', '', {
                         path: '/',
+                        domain: config.domain,
                         expires: new Date(1970, 1, 1, 0, 0, 0, 0),
                     }),
                 },
@@ -32,6 +34,7 @@ export function logoutCompleteHandler(config: Config) {
                     key: 'Set-Cookie',
                     value: cookie.serialize('NONCE', '', {
                         path: '/',
+                        domain: config.domain,
                         httpOnly: true,
                     }),
                 },

--- a/libs/lambda-edge-openid-auth/src/lib/handlers/redirect.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/handlers/redirect.ts
@@ -41,6 +41,7 @@ export function redirect(
                     key: 'Set-Cookie',
                     value: cookie.serialize('IDP', idpConfig.name, {
                         path: '/',
+                        secure: true,
                         domain: config.domain,
                         httpOnly: true,
                     }),
@@ -57,6 +58,7 @@ export function redirect(
                     key: 'Set-Cookie',
                     value: cookie.serialize('NONCE', n[1], {
                         path: '/',
+                        secure: true,
                         domain: config.domain,
                         httpOnly: true,
                     }),

--- a/libs/lambda-edge-openid-auth/src/lib/handlers/redirect.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/handlers/redirect.ts
@@ -41,6 +41,7 @@ export function redirect(
                     key: 'Set-Cookie',
                     value: cookie.serialize('IDP', idpConfig.name, {
                         path: '/',
+                        domain: config.domain,
                         httpOnly: true,
                     }),
                 },
@@ -48,6 +49,7 @@ export function redirect(
                     key: 'Set-Cookie',
                     value: cookie.serialize('TOKEN', '', {
                         path: '/',
+                        domain: config.domain,
                         expires: new Date(1970, 1, 1, 0, 0, 0, 0),
                     }),
                 },
@@ -55,6 +57,7 @@ export function redirect(
                     key: 'Set-Cookie',
                     value: cookie.serialize('NONCE', n[1], {
                         path: '/',
+                        domain: config.domain,
                         httpOnly: true,
                     }),
                 },

--- a/libs/lambda-edge-openid-auth/src/lib/handlers/validate-token.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/handlers/validate-token.ts
@@ -20,7 +20,7 @@ export async function validateTokenHandler(
 
     if (!decodedData || !decodedData.header.kid) {
         log.warn({ token: token }, 'Missing data')
-        return badRequest()
+        return badRequest(config)
     }
 
     const pem = idpConfig.keyIdLookup[decodedData.header.kid]

--- a/libs/lambda-edge-openid-auth/src/lib/handlers/validate-token.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/handlers/validate-token.ts
@@ -26,7 +26,7 @@ export async function validateTokenHandler(
     const pem = idpConfig.keyIdLookup[decodedData.header.kid]
     if (!pem) {
         log.warn({ kid: decodedData.header.kid }, 'Missing pem')
-        return unauthorized('Unknown kid', '', '')
+        return unauthorized(config, 'Unknown kid', '', '')
     }
 
     try {
@@ -43,10 +43,16 @@ export async function validateTokenHandler(
                 return redirect(config, idpConfig, request)
             case 'JsonWebTokenError':
                 log.info('JWT error, unauthorized.')
-                return unauthorized('Json Web Token Error', err.message, '')
+                return unauthorized(
+                    config,
+                    'Json Web Token Error',
+                    err.message,
+                    '',
+                )
             default:
                 log.info('Unknown JWT error, unauthorized.')
                 return unauthorized(
+                    config,
                     'Unknown JWT',
                     'User ' + decodedData.payload.email + ' is not permitted.',
                     '',

--- a/libs/lambda-edge-openid-auth/src/lib/viewer-request.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/viewer-request.ts
@@ -48,7 +48,7 @@ export const authenticateViewerRequest = async (
         const idpConfig = idps.find(({ name }) => idp === name)
         if (!idpConfig) {
             log.warn(`Unknown idp: ${idp}`)
-            return badRequest()
+            return badRequest(config)
         }
 
         if (isLoginPath) {

--- a/libs/lambda-edge-openid-auth/src/lib/views/bad-request.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/views/bad-request.ts
@@ -1,6 +1,8 @@
 import { CloudFrontResultResponse } from 'aws-lambda/common/cloudfront'
+import cookie from 'cookie'
+import { Config } from '../config'
 
-export function badRequest(): CloudFrontResultResponse {
+export function badRequest(config: Config): CloudFrontResultResponse {
     const page = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -19,5 +21,33 @@ export function badRequest(): CloudFrontResultResponse {
         status: '400',
         statusDescription: 'Bad Request',
         body: page,
+        headers: {
+            'set-cookie': [
+                {
+                    key: 'Set-Cookie',
+                    value: cookie.serialize('TOKEN', '', {
+                        path: '/',
+                        domain: config.domain,
+                        expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+                    }),
+                },
+                {
+                    key: 'Set-Cookie',
+                    value: cookie.serialize('NONCE', '', {
+                        path: '/',
+                        domain: config.domain,
+                        expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+                    }),
+                },
+                {
+                    key: 'Set-Cookie',
+                    value: cookie.serialize('IDP', '', {
+                        path: '/',
+                        domain: config.domain,
+                        expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+                    }),
+                },
+            ],
+        },
     }
 }

--- a/libs/lambda-edge-openid-auth/src/lib/views/unauthorized.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/views/unauthorized.ts
@@ -1,7 +1,9 @@
 import { CloudFrontResultResponse } from 'aws-lambda'
 import cookie from 'cookie'
+import { Config } from '../config'
 
 export function unauthorized(
+    config: Config,
     error: string,
     error_description: string,
     error_uri: string,
@@ -31,6 +33,7 @@ export function unauthorized(
                     key: 'Set-Cookie',
                     value: cookie.serialize('TOKEN', '', {
                         path: '/',
+                        domain: config.domain,
                         expires: new Date(1970, 1, 1, 0, 0, 0, 0),
                     }),
                 },
@@ -38,6 +41,7 @@ export function unauthorized(
                     key: 'Set-Cookie',
                     value: cookie.serialize('NONCE', '', {
                         path: '/',
+                        domain: config.domain,
                         expires: new Date(1970, 1, 1, 0, 0, 0, 0),
                     }),
                 },


### PR DESCRIPTION
As per https://github.com/Widen/cloudfront-auth/issues/36#issuecomment-864310799

By default, the cookies may be scoped to swmdigital.io, as per https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie

This PR makes it explicit, and also sets secure (to prevent mitm attacks)