### PR TITLE
Token refresh

### DIFF
--- a/.changeset/nervous-ties-laugh.md
+++ b/.changeset/nervous-ties-laugh.md
@@ -1,0 +1,5 @@
+---
+'@wanews/lambda-edge-openid-auth': minor
+---
+
+Added token refresh endpoint

--- a/libs/lambda-edge-openid-auth/src/lib/config.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/config.ts
@@ -30,6 +30,7 @@ export interface Config {
     logoutCompletePath: string
     logoutPath: string
     loginPath: string
+    refreshPath: string
     publicUrl: string
     domain: string
     redirectUri: string
@@ -53,6 +54,7 @@ export function getConfig(
             logoutCompletePath,
             logoutPath: '/logout',
             loginPath: '/login',
+            refreshPath: '/refresh-token',
             publicUrl,
             domain: request.headers.host[0].value,
             redirectUri: `${publicUrl}${callbackPath}`,

--- a/libs/lambda-edge-openid-auth/src/lib/handlers/callback.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/handlers/callback.ts
@@ -1,14 +1,15 @@
 import { CloudFrontRequest, CloudFrontResultResponse } from 'aws-lambda'
 import cookie from 'cookie'
-import jwt from 'jsonwebtoken'
-import fetch from 'node-fetch'
 import queryString from 'query-string'
 import { Config, Idp } from '../config'
-import { redirect } from './redirect'
-import { unauthorized } from '../views/unauthorized'
-import { validateNonce } from '../utils/nonce'
-import { badRequest } from '../views/bad-request'
 import { Logger } from 'typescript-log'
+import {
+    fetchToken,
+    refreshTokenExpireEpoch,
+    tokenExpireEpoch,
+    verifyToken,
+} from '../utils/auth-token'
+import { BadRequest, Unauthorized } from '../utils/errors'
 
 const IDP_ERRORS: { [key: string]: string } = {
     invalid_request: 'Invalid Request',
@@ -20,19 +21,13 @@ const IDP_ERRORS: { [key: string]: string } = {
     temporarily_unavailable: 'Temporarily Unavailable',
 }
 
-export async function callbackHandler(
-    config: Config,
-    idpConfig: Idp,
-    log: Logger,
-    request: CloudFrontRequest,
-    nonce?: string,
-): Promise<CloudFrontResultResponse> {
-    const queryDict = queryString.parse(request.querystring)
+function parseCallback(log: Logger, qs: string) {
+    const queryDict = queryString.parse(qs)
 
     // Check for error response (https://tools.ietf.org/html/rfc6749#section-4.2.2.1)
     if (queryDict.error) {
         if (Array.isArray(queryDict.error)) {
-            return badRequest(config)
+            throw new BadRequest('Error querystring param is expected')
         }
         const error = IDP_ERRORS[queryDict.error] || queryDict.error
 
@@ -49,144 +44,99 @@ export async function callbackHandler(
             error_uri = queryDict.error_uri
         }
 
-        return unauthorized(config, error, error_description, error_uri)
+        throw new Unauthorized(error, error_description, error_uri)
     }
 
     // Verify code is in querystring
-    if (!queryDict.code) {
-        return unauthorized(config, 'No Code Found', '', '')
+    if (!queryDict.code || typeof queryDict.code !== 'string') {
+        throw new Unauthorized('No Code Found')
     }
 
     // Verify state in querystring is a string
     if (!queryDict.state || typeof queryDict.state !== 'string') {
         log.warn({ state: queryDict.state }, 'invalid state')
-        return badRequest(config)
+        throw new BadRequest('Invalid state')
     }
 
-    // Exchange code for authorization token
-    const tokenRequest = {
-        redirect_uri: config.redirectUri,
-        grant_type: 'authorization_code',
+    return {
         code: queryDict.code,
-        client_id: idpConfig.clientId,
-        client_secret: idpConfig.clientSecret,
+        state: queryDict.state,
     }
-    const postData = queryString.stringify(tokenRequest)
-    log.info('Requesting access token.')
-    const tokenResponse = await fetch(idpConfig.discoveryDoc.token_endpoint, {
-        method: 'POST',
+}
+
+export async function callbackHandler(
+    config: Config,
+    idpConfig: Idp,
+    log: Logger,
+    request: CloudFrontRequest,
+    nonce?: string,
+): Promise<CloudFrontResultResponse> {
+    const { code, state } = parseCallback(log, request.querystring)
+
+    const {
+        id_token: token,
+        refresh_token: refreshToken,
+        expires_in: tokenExpiresIn,
+    } = await fetchToken(log, idpConfig, config.redirectUri, code)
+
+    const payload = verifyToken(log, idpConfig, token, nonce)
+
+    const tokenExpiry = tokenExpireEpoch(payload.exp, tokenExpiresIn)
+    const refreshTokenExpiry = refreshTokenExpireEpoch(tokenExpiry)
+
+    // Once verified, create new JWT for this server
+    return {
+        status: '302',
+        statusDescription: 'Found',
+        body: 'ID token retrieved.',
         headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
+            location: [
+                {
+                    key: 'Location',
+                    value: state,
+                },
+            ],
+            'set-cookie': [
+                {
+                    key: 'Set-Cookie',
+                    value: cookie.serialize('TOKEN', token, {
+                        path: '/',
+                        secure: true,
+                        sameSite: 'lax',
+                        domain: config.domain,
+                        expires: new Date(tokenExpiry * 1000),
+                    }),
+                },
+                {
+                    key: 'Set-Cookie',
+                    value: cookie.serialize('NONCE', '', {
+                        path: '/',
+                        domain: config.domain,
+                        expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+                    }),
+                },
+                ...(refreshToken
+                    ? [
+                          {
+                              key: 'Set-Cookie',
+                              value: cookie.serialize(
+                                  'REFRESH_TOKEN',
+                                  refreshToken,
+                                  {
+                                      path: '/',
+                                      secure: true,
+                                      sameSite: 'lax',
+                                      domain: config.domain,
+                                      expires: new Date(
+                                          refreshTokenExpiry * 1000,
+                                      ),
+                                      httpOnly: true,
+                                  },
+                              ),
+                          },
+                      ]
+                    : []),
+            ],
         },
-        body: new URLSearchParams(postData).toString(),
-    })
-    if (tokenResponse.status !== 200) {
-        log.error(
-            {
-                errorBody: await tokenResponse.text(),
-                statusCode: tokenResponse.status,
-            },
-            'Token exchange failed',
-        )
-        return badRequest(config)
-    }
-    const parsedTokenResponse: any = await tokenResponse.json()
-
-    log.info('Decoding JWT')
-    const decodedData = jwt.decode(parsedTokenResponse.id_token, {
-        complete: true,
-    })
-
-    if (!decodedData || !decodedData.header.kid) {
-        log.warn({ res: parsedTokenResponse }, 'Missing data')
-        return badRequest(config)
-    }
-
-    log.info('Searching for JWK from discovery document')
-    const pem = idpConfig.keyIdLookup[decodedData.header.kid]
-    if (!pem) {
-        log.warn({ kid: decodedData.header.kid }, 'Missing pem')
-        return unauthorized(config, 'Unknown kid', '', '')
-    }
-
-    try {
-        log.info('Verifying JWT')
-        const decoded = jwt.verify(parsedTokenResponse.id_token, pem, {
-            algorithms: ['RS256'],
-        })
-
-        if (typeof decoded === 'string') {
-            log.warn(
-                { payload: decoded },
-                'Failed to verify JWT, returned value is string',
-            )
-            return badRequest(config)
-        }
-
-        if (!nonce || !validateNonce(decoded.nonce, nonce)) {
-            return unauthorized(config, 'Nonce Verification Failed', '', '')
-        }
-
-        // Once verified, create new JWT for this server
-        return {
-            status: '302',
-            statusDescription: 'Found',
-            body: 'ID token retrieved.',
-            headers: {
-                location: [
-                    {
-                        key: 'Location',
-                        value: queryDict.state,
-                    },
-                ],
-                'set-cookie': [
-                    {
-                        key: 'Set-Cookie',
-                        value: cookie.serialize(
-                            'TOKEN',
-                            parsedTokenResponse.id_token,
-                            {
-                                path: '/',
-                                secure: true,
-                                domain: config.domain,
-                                expires: decoded.exp
-                                    ? new Date(decoded.exp * 1000)
-                                    : undefined,
-                            },
-                        ),
-                    },
-                    {
-                        key: 'Set-Cookie',
-                        value: cookie.serialize('NONCE', '', {
-                            path: '/',
-                            domain: config.domain,
-                            expires: new Date(1970, 1, 1, 0, 0, 0, 0),
-                        }),
-                    },
-                ],
-            },
-        }
-    } catch (err: any) {
-        switch (err.name) {
-            case 'TokenExpiredError':
-                log.info('Token expired, redirecting to OIDC provider.')
-                return redirect(config, idpConfig, request)
-            case 'JsonWebTokenError':
-                log.info({ err }, 'JWT error, unauthorized.')
-                return unauthorized(
-                    config,
-                    'Json Web Token Error',
-                    err.message,
-                    '',
-                )
-            default:
-                log.info('Unknown JWT error, unauthorized.')
-                return unauthorized(
-                    config,
-                    'Unknown JWT',
-                    `User ${decodedData.payload.email} is not permitted.`,
-                    '',
-                )
-        }
     }
 }

--- a/libs/lambda-edge-openid-auth/src/lib/handlers/logout-complete.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/handlers/logout-complete.ts
@@ -13,14 +13,16 @@ export function logoutCompleteHandler(config: Config) {
                     value: config.publicUrl,
                 },
             ],
-            'set-cookie': ['TOKEN', 'NONCE', 'IDP'].map((name) => ({
-                key: 'Set-Cookie',
-                value: cookie.serialize(name, '', {
-                    path: '/',
-                    domain: config.domain,
-                    expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+            'set-cookie': ['TOKEN', 'REFRESH_TOKEN', 'NONCE', 'IDP'].map(
+                (name) => ({
+                    key: 'Set-Cookie',
+                    value: cookie.serialize(name, '', {
+                        path: '/',
+                        domain: config.domain,
+                        expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+                    }),
                 }),
-            })),
+            ),
         },
     }
 }

--- a/libs/lambda-edge-openid-auth/src/lib/handlers/logout-complete.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/handlers/logout-complete.ts
@@ -13,35 +13,14 @@ export function logoutCompleteHandler(config: Config) {
                     value: config.publicUrl,
                 },
             ],
-            'set-cookie': [
-                {
-                    key: 'Set-Cookie',
-                    value: cookie.serialize('IDP', '', {
-                        path: '/',
-                        secure: true,
-                        domain: config.domain,
-                        httpOnly: true,
-                    }),
-                },
-                {
-                    key: 'Set-Cookie',
-                    value: cookie.serialize('TOKEN', '', {
-                        path: '/',
-                        secure: true,
-                        domain: config.domain,
-                        expires: new Date(1970, 1, 1, 0, 0, 0, 0),
-                    }),
-                },
-                {
-                    key: 'Set-Cookie',
-                    value: cookie.serialize('NONCE', '', {
-                        path: '/',
-                        secure: true,
-                        domain: config.domain,
-                        httpOnly: true,
-                    }),
-                },
-            ],
+            'set-cookie': ['TOKEN', 'NONCE', 'IDP'].map((name) => ({
+                key: 'Set-Cookie',
+                value: cookie.serialize(name, '', {
+                    path: '/',
+                    domain: config.domain,
+                    expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+                }),
+            })),
         },
     }
 }

--- a/libs/lambda-edge-openid-auth/src/lib/handlers/redirect.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/handlers/redirect.ts
@@ -16,7 +16,7 @@ export function redirect(
         redirect_uri: config.redirectUri,
         response_type: 'code',
         response_mode: 'query',
-        scope: 'openid',
+        scope: 'openid offline_access',
         nonce: n[0],
         state: queryDict.next || '/',
         client_id: idpConfig.clientId,
@@ -47,6 +47,14 @@ export function redirect(
                 {
                     key: 'Set-Cookie',
                     value: cookie.serialize('TOKEN', '', {
+                        path: '/',
+                        domain: config.domain,
+                        expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+                    }),
+                },
+                {
+                    key: 'Set-Cookie',
+                    value: cookie.serialize('REFRESH_TOKEN', '', {
                         path: '/',
                         domain: config.domain,
                         expires: new Date(1970, 1, 1, 0, 0, 0, 0),

--- a/libs/lambda-edge-openid-auth/src/lib/handlers/redirect.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/handlers/redirect.ts
@@ -41,9 +41,7 @@ export function redirect(
                     key: 'Set-Cookie',
                     value: cookie.serialize('IDP', idpConfig.name, {
                         path: '/',
-                        secure: true,
                         domain: config.domain,
-                        httpOnly: true,
                     }),
                 },
                 {
@@ -58,9 +56,7 @@ export function redirect(
                     key: 'Set-Cookie',
                     value: cookie.serialize('NONCE', n[1], {
                         path: '/',
-                        secure: true,
                         domain: config.domain,
-                        httpOnly: true,
                     }),
                 },
             ],

--- a/libs/lambda-edge-openid-auth/src/lib/handlers/refresh-token.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/handlers/refresh-token.ts
@@ -1,0 +1,104 @@
+import { CloudFrontResultResponse } from 'aws-lambda'
+import { Config, Idp } from '../config'
+import { Logger } from 'typescript-log'
+import cookie from 'cookie'
+import {
+    decodeToken,
+    fetchRefreshedToken,
+    refreshTokenExpireEpoch,
+    tokenExpireEpoch,
+    verifyToken,
+} from '../utils/auth-token'
+
+export async function refreshTokenHandler(
+    config: Config,
+    idpConfig: Idp,
+    log: Logger,
+    token: string,
+    refreshToken?: string,
+): Promise<CloudFrontResultResponse> {
+    // decode the token to get the expiry
+    const {
+        payload: { exp: currentTokenExp },
+    } = decodeToken(log, token)
+
+    // refresh the token 10mins before the expiry
+    if (currentTokenExp && Date.now() / 1000 > currentTokenExp - 60 * 10) {
+        if (!refreshToken) {
+            return {
+                status: '400',
+                statusDescription: 'Bad Request',
+                body: 'No refresh token available',
+            }
+        }
+
+        const tokenResponse = await fetchRefreshedToken(
+            log,
+            idpConfig,
+            config.redirectUri,
+            refreshToken,
+        )
+
+        if (tokenResponse) {
+            const {
+                id_token: newToken,
+                refresh_token: newRefreshToken,
+                expires_in: newTokenExpiresIn,
+            } = tokenResponse
+
+            const payload = verifyToken(log, idpConfig, newToken)
+
+            const tokenExpiry = tokenExpireEpoch(payload.exp, newTokenExpiresIn)
+            const refreshTokenExpiry = refreshTokenExpireEpoch(tokenExpiry)
+
+            return {
+                status: '201',
+                statusDescription: 'Ok',
+                body: 'Token refreshed successfully',
+                headers: {
+                    'set-cookie': [
+                        {
+                            key: 'Set-Cookie',
+                            value: cookie.serialize('TOKEN', newToken, {
+                                path: '/',
+                                secure: true,
+                                sameSite: 'lax',
+                                domain: config.domain,
+                                expires: new Date(tokenExpiry * 1000),
+                            }),
+                        },
+                        {
+                            key: 'Set-Cookie',
+                            value: cookie.serialize(
+                                'REFRESH_TOKEN',
+                                newRefreshToken,
+                                {
+                                    path: '/',
+                                    secure: true,
+                                    sameSite: 'lax',
+                                    domain: config.domain,
+                                    expires: new Date(
+                                        refreshTokenExpiry * 1000,
+                                    ),
+                                    httpOnly: true,
+                                },
+                            ),
+                        },
+                    ],
+                },
+            }
+        } else {
+            return {
+                status: '400',
+                statusDescription: 'Bad Request',
+                body: 'Failed to refresh token',
+            }
+        }
+    }
+
+    return {
+        status: '200',
+        statusDescription: 'Ok',
+        body: 'No token refresh required at the moment',
+    }
+}

--- a/libs/lambda-edge-openid-auth/src/lib/handlers/validate-token.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/handlers/validate-token.ts
@@ -1,10 +1,7 @@
 import { CloudFrontRequest } from 'aws-lambda'
-import jwt from 'jsonwebtoken'
 import { Config, Idp } from '../config'
-import { redirect } from './redirect'
-import { unauthorized } from '../views/unauthorized'
-import { badRequest } from '../views/bad-request'
 import { Logger } from 'typescript-log'
+import { verifyToken } from '../utils/auth-token'
 
 export async function validateTokenHandler(
     config: Config,
@@ -13,50 +10,6 @@ export async function validateTokenHandler(
     request: CloudFrontRequest,
     token: string,
 ) {
-    console.log('Searching for JWK from discovery document')
-    const decodedData = jwt.decode(token, {
-        complete: true,
-    })
-
-    if (!decodedData || !decodedData.header.kid) {
-        log.warn({ token: token }, 'Missing data')
-        return badRequest(config)
-    }
-
-    const pem = idpConfig.keyIdLookup[decodedData.header.kid]
-    if (!pem) {
-        log.warn({ kid: decodedData.header.kid }, 'Missing pem')
-        return unauthorized(config, 'Unknown kid', '', '')
-    }
-
-    try {
-        // Verify the JWT, the payload email, and that the email ends with configured hosted domain
-        jwt.verify(token, pem, {
-            algorithms: ['RS256'],
-        })
-
-        return request
-    } catch (err: any) {
-        switch (err.name) {
-            case 'TokenExpiredError':
-                log.info('Token expired, redirecting to OIDC provider.')
-                return redirect(config, idpConfig, request)
-            case 'JsonWebTokenError':
-                log.info('JWT error, unauthorized.')
-                return unauthorized(
-                    config,
-                    'Json Web Token Error',
-                    err.message,
-                    '',
-                )
-            default:
-                log.info('Unknown JWT error, unauthorized.')
-                return unauthorized(
-                    config,
-                    'Unknown JWT',
-                    'User ' + decodedData.payload.email + ' is not permitted.',
-                    '',
-                )
-        }
-    }
+    verifyToken(log, idpConfig, token)
+    return request
 }

--- a/libs/lambda-edge-openid-auth/src/lib/utils/auth-token.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/utils/auth-token.ts
@@ -1,0 +1,166 @@
+import { Logger } from 'typescript-log'
+import { Idp } from '../config'
+import { http, HttpError } from './http'
+import queryString from 'query-string'
+import { BadRequest, Unauthorized } from './errors'
+import jwt from 'jsonwebtoken'
+import { validateNonce } from './nonce'
+
+export interface AccessTokenResponse {
+    access_token: string
+    expires_in: number
+    refresh_token?: string
+    token_type: string
+    scope: string
+    id_token: string
+}
+
+export const tokenExpireEpoch = (exp: number | undefined, expiresIn: number) =>
+    exp ?? new Date().getTime() / 1000 + expiresIn
+
+export const refreshTokenExpireEpoch = (exp: number) => exp + 60 * 60 * 24 * 7
+
+export async function fetchToken(
+    log: Logger,
+    idpConfig: Idp,
+    redirectUri: string,
+    code: string,
+) {
+    log.info('Requesting access token.')
+    try {
+        const tokenResponse = await http<AccessTokenResponse>(
+            idpConfig.discoveryDoc.token_endpoint,
+            {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: new URLSearchParams(
+                    queryString.stringify({
+                        redirect_uri: redirectUri,
+                        grant_type: 'authorization_code',
+                        code,
+                        client_id: idpConfig.clientId,
+                        client_secret: idpConfig.clientSecret,
+                    }),
+                ).toString(),
+            },
+        )
+        if (!tokenResponse.parsedBody) {
+            throw new Error('Empty response')
+        }
+        return tokenResponse.parsedBody
+    } catch (err) {
+        if (err instanceof HttpError) {
+            log.error(err.response, 'Token exchange failed')
+        } else if (err instanceof Error) {
+            log.error(err, 'Unknown error occurred during token exchange')
+        }
+        throw new BadRequest('Token exchange failed')
+    }
+}
+
+export async function fetchRefreshedToken(
+    log: Logger,
+    idpConfig: Idp,
+    redirectUri: string,
+    refreshToken: string,
+) {
+    log.info('Requesting refresh token.')
+    try {
+        const tokenResponse = await http<Required<AccessTokenResponse>>(
+            idpConfig.discoveryDoc.token_endpoint,
+            {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: new URLSearchParams(
+                    queryString.stringify({
+                        client_id: idpConfig.clientId,
+                        client_secret: idpConfig.clientSecret,
+                        grant_type: 'refresh_token',
+                        refresh_token: refreshToken,
+                        scope: 'openid offline_access',
+                    }),
+                ).toString(),
+            },
+        )
+        return tokenResponse.parsedBody
+    } catch (err) {
+        if (err instanceof HttpError) {
+            log.warn(err.response, 'Token refresh failed')
+        } else if (err instanceof Error) {
+            log.warn(err, 'Unknown error occurred during token refresh')
+        }
+    }
+    return null
+}
+
+export function decodeToken(log: Logger, token: string) {
+    log.info('Decoding JWT')
+    const decodedData = jwt.decode(token, {
+        complete: true,
+    })
+
+    if (!decodedData) {
+        log.warn({ idToken: token }, 'Missing data')
+        throw new BadRequest('Missing data')
+    }
+
+    return decodedData
+}
+
+export function verifyToken(
+    log: Logger,
+    idpConfig: Idp,
+    token: string,
+    nonce?: string,
+) {
+    const {
+        header: { kid },
+    } = decodeToken(log, token)
+
+    log.info('Searching for JWK from discovery document')
+    const pem = idpConfig.keyIdLookup[kid || '']
+    if (!pem) {
+        log.warn({ kid }, 'Missing pem')
+        throw new Unauthorized('Unknown kid')
+    }
+
+    try {
+        log.info('Verifying JWT')
+        const payload = jwt.verify(token, pem, {
+            algorithms: ['RS256'],
+            audience: idpConfig.clientId,
+            issuer: idpConfig.discoveryDoc.issuer,
+        })
+
+        if (typeof payload === 'string') {
+            log.warn(
+                { payload },
+                'Failed to verify JWT, returned value is string',
+            )
+            throw new BadRequest('Invalid payload')
+        }
+
+        if (nonce && !validateNonce(payload.nonce, nonce)) {
+            throw new Unauthorized('Nonce Verification Failed')
+        }
+
+        return payload
+    } catch (err: any) {
+        switch (err.name) {
+            case 'BadRequest':
+            case 'Unauthorized':
+            case 'TokenExpiredError':
+                throw err
+            case 'JsonWebTokenError':
+                log.info('JWT error, unauthorized.')
+                throw new Unauthorized(`Json Web Token Error ${err.message}`)
+            default:
+                log.info('Unknown JWT error, unauthorized.')
+                throw new Unauthorized(`Unknown JWT error ${err}`)
+        }
+    }
+}

--- a/libs/lambda-edge-openid-auth/src/lib/utils/errors.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/utils/errors.ts
@@ -1,0 +1,27 @@
+export class BadRequest extends Error {
+    __proto__: BadRequest
+
+    constructor(message: string) {
+        super(message)
+
+        this.constructor = BadRequest
+        this.name = 'BadRequest'
+        this.__proto__ = BadRequest.prototype
+    }
+}
+
+export class Unauthorized extends Error {
+    __proto__: Unauthorized
+    public readonly description?: string
+    public readonly uri?: string
+
+    constructor(message: string, description?: string, uri?: string) {
+        super(message)
+
+        this.constructor = Unauthorized
+        this.name = 'Unauthorized'
+        this.description = description ?? ''
+        this.uri = uri ?? ''
+        this.__proto__ = Unauthorized.prototype
+    }
+}

--- a/libs/lambda-edge-openid-auth/src/lib/utils/http.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/utils/http.ts
@@ -1,0 +1,51 @@
+import fetch, { RequestInfo, RequestInit, Response } from 'node-fetch'
+
+interface HttpResponse<T> extends Response {
+    parsedBody?: T
+}
+
+export interface SimpleResponse {
+    status: number
+    statusText: string
+    url?: string
+    errorBody?: string
+}
+
+export class HttpError extends Error {
+    __proto__: HttpError
+    response: SimpleResponse
+
+    constructor(response: Response, errorBody?: string) {
+        super(response.status.toString())
+
+        // This is required to make `err instanceof StartupError` work
+        this.constructor = HttpError
+        this.__proto__ = HttpError.prototype
+
+        this.response = {
+            status: response.status,
+            statusText: response.statusText,
+            url: response.url,
+            errorBody,
+        }
+    }
+}
+
+export async function http<T>(
+    url: RequestInfo,
+    init?: RequestInit,
+): Promise<HttpResponse<T>> {
+    const response: HttpResponse<T> = await fetch(url, init)
+
+    try {
+        response.parsedBody = await response.json()
+        // eslint-disable-next-line no-empty
+    } catch (err) {}
+
+    if (!response.ok) {
+        const errorBody = await response.text()
+        throw new HttpError(response, errorBody)
+    }
+
+    return response
+}

--- a/libs/lambda-edge-openid-auth/src/lib/viewer-request.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/viewer-request.ts
@@ -1,4 +1,4 @@
-import { CloudFrontRequest } from 'aws-lambda'
+import { CloudFrontRequest, CloudFrontRequestResult } from 'aws-lambda'
 import queryString from 'query-string'
 import { callbackHandler } from './handlers/callback'
 import { getConfig, RawConfig } from './config'
@@ -10,8 +10,11 @@ import { validateTokenHandler } from './handlers/validate-token'
 import { badRequest } from './views/bad-request'
 import { logoutHandler } from './handlers/logout'
 import { logoutCompleteHandler } from './handlers/logout-complete'
-import { CloudFrontRequestResult } from 'aws-lambda/trigger/cloudfront-request'
 import { Logger } from 'typescript-log'
+import { refreshTokenHandler } from './handlers/refresh-token'
+import { TokenExpiredError } from 'jsonwebtoken'
+import { BadRequest, Unauthorized } from './utils/errors'
+import { unauthorized } from './views/unauthorized'
 
 export const authenticateViewerRequest = async (
     rawConfig: RawConfig,
@@ -51,41 +54,67 @@ export const authenticateViewerRequest = async (
             return badRequest(config)
         }
 
-        if (isLoginPath) {
+        try {
+            if (isLoginPath) {
+                return redirect(config, idpConfig, request)
+            }
+
+            if (request.uri.startsWith(config.callbackPath)) {
+                log.info('Callback from OIDC provider received')
+                return callbackHandler(
+                    config,
+                    idpConfig,
+                    log,
+                    request,
+                    cookies.NONCE,
+                )
+            }
+
+            if (request.uri.startsWith(config.logoutCompletePath)) {
+                return logoutCompleteHandler(config)
+            }
+
+            if (request.uri.startsWith(config.logoutPath)) {
+                return logoutHandler(config, idpConfig)
+            }
+
+            if (cookies && cookies.TOKEN) {
+                if (request.uri.startsWith(config.refreshPath)) {
+                    return refreshTokenHandler(
+                        config,
+                        idpConfig,
+                        log,
+                        cookies.TOKEN,
+                        cookies.REFRESH_TOKEN,
+                    )
+                }
+
+                log.info('Request received with TOKEN cookie. Validating.')
+                return validateTokenHandler(
+                    config,
+                    idpConfig,
+                    log,
+                    request,
+                    cookies.TOKEN,
+                )
+            }
+
             return redirect(config, idpConfig, request)
+        } catch (err: any) {
+            if (err instanceof TokenExpiredError) {
+                return redirect(config, idpConfig, request)
+            } else if (err instanceof BadRequest) {
+                return badRequest(config)
+            } else if (err instanceof Unauthorized) {
+                return unauthorized(
+                    config,
+                    err.message,
+                    err.description,
+                    err.uri,
+                )
+            }
+            throw err
         }
-
-        if (request.uri.startsWith(config.callbackPath)) {
-            log.info('Callback from OIDC provider received')
-            return callbackHandler(
-                config,
-                idpConfig,
-                log,
-                request,
-                cookies.NONCE,
-            )
-        }
-
-        if (request.uri.startsWith(config.logoutCompletePath)) {
-            return logoutCompleteHandler(config)
-        }
-
-        if (request.uri.startsWith(config.logoutPath)) {
-            return logoutHandler(config, idpConfig)
-        }
-
-        if (cookies && cookies.TOKEN) {
-            log.info('Request received with TOKEN cookie. Validating.')
-            return validateTokenHandler(
-                config,
-                idpConfig,
-                log,
-                request,
-                cookies.TOKEN,
-            )
-        }
-
-        return redirect(config, idpConfig, request)
     } catch (err: any) {
         log.error(err, 'Error encountered when authenticating request')
         return internalServerError()

--- a/libs/lambda-edge-openid-auth/src/lib/views/bad-request.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/views/bad-request.ts
@@ -22,32 +22,14 @@ export function badRequest(config: Config): CloudFrontResultResponse {
         statusDescription: 'Bad Request',
         body: page,
         headers: {
-            'set-cookie': [
-                {
-                    key: 'Set-Cookie',
-                    value: cookie.serialize('TOKEN', '', {
-                        path: '/',
-                        domain: config.domain,
-                        expires: new Date(1970, 1, 1, 0, 0, 0, 0),
-                    }),
-                },
-                {
-                    key: 'Set-Cookie',
-                    value: cookie.serialize('NONCE', '', {
-                        path: '/',
-                        domain: config.domain,
-                        expires: new Date(1970, 1, 1, 0, 0, 0, 0),
-                    }),
-                },
-                {
-                    key: 'Set-Cookie',
-                    value: cookie.serialize('IDP', '', {
-                        path: '/',
-                        domain: config.domain,
-                        expires: new Date(1970, 1, 1, 0, 0, 0, 0),
-                    }),
-                },
-            ],
+            'set-cookie': ['TOKEN', 'NONCE', 'IDP'].map((name) => ({
+                key: 'Set-Cookie',
+                value: cookie.serialize(name, '', {
+                    path: '/',
+                    domain: config.domain,
+                    expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+                }),
+            })),
         },
     }
 }

--- a/libs/lambda-edge-openid-auth/src/lib/views/bad-request.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/views/bad-request.ts
@@ -22,14 +22,16 @@ export function badRequest(config: Config): CloudFrontResultResponse {
         statusDescription: 'Bad Request',
         body: page,
         headers: {
-            'set-cookie': ['TOKEN', 'NONCE', 'IDP'].map((name) => ({
-                key: 'Set-Cookie',
-                value: cookie.serialize(name, '', {
-                    path: '/',
-                    domain: config.domain,
-                    expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+            'set-cookie': ['TOKEN', 'REFRESH_TOKEN', 'NONCE', 'IDP'].map(
+                (name) => ({
+                    key: 'Set-Cookie',
+                    value: cookie.serialize(name, '', {
+                        path: '/',
+                        domain: config.domain,
+                        expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+                    }),
                 }),
-            })),
+            ),
         },
     }
 }

--- a/libs/lambda-edge-openid-auth/src/lib/views/unauthorized.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/views/unauthorized.ts
@@ -28,24 +28,14 @@ export function unauthorized(
         statusDescription: 'Unauthorized',
         body: page,
         headers: {
-            'set-cookie': [
-                {
-                    key: 'Set-Cookie',
-                    value: cookie.serialize('TOKEN', '', {
-                        path: '/',
-                        domain: config.domain,
-                        expires: new Date(1970, 1, 1, 0, 0, 0, 0),
-                    }),
-                },
-                {
-                    key: 'Set-Cookie',
-                    value: cookie.serialize('NONCE', '', {
-                        path: '/',
-                        domain: config.domain,
-                        expires: new Date(1970, 1, 1, 0, 0, 0, 0),
-                    }),
-                },
-            ],
+            'set-cookie': ['TOKEN', 'NONCE'].map((name) => ({
+                key: 'Set-Cookie',
+                value: cookie.serialize(name, '', {
+                    path: '/',
+                    domain: config.domain,
+                    expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+                }),
+            })),
         },
     }
 }

--- a/libs/lambda-edge-openid-auth/src/lib/views/unauthorized.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/views/unauthorized.ts
@@ -5,8 +5,8 @@ import { Config } from '../config'
 export function unauthorized(
     config: Config,
     error: string,
-    error_description: string,
-    error_uri: string,
+    error_description?: string,
+    error_uri?: string,
 ): CloudFrontResultResponse {
     const page = `<!DOCTYPE html>
 <html lang="en">
@@ -17,7 +17,9 @@ export function unauthorized(
     <style type="text/css">/*! normalize.css v5.0.0 | MIT License | github.com/necolas/normalize.css */html{font-family:sans-serif;line-height:1.15;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}body{margin:0}article,aside,footer,header,nav,section{display:block}h1{font-size:2em;margin:.67em 0}figcaption,figure,main{display:block}figure{margin:1em 40px}hr{box-sizing:content-box;height:0;overflow:visible}pre{font-family:monospace,monospace;font-size:1em}a{background-color:transparent;-webkit-text-decoration-skip:objects}a:active,a:hover{outline-width:0}abbr[title]{border-bottom:none;text-decoration:underline;text-decoration:underline dotted}b,strong{font-weight:inherit}b,strong{font-weight:bolder}code,kbd,samp{font-family:monospace,monospace;font-size:1em}dfn{font-style:italic}mark{background-color:#ff0;color:#000}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}audio,video{display:inline-block}audio:not([controls]){display:none;height:0}img{border-style:none}svg:not(:root){overflow:hidden}button,input,optgroup,select,textarea{font-family:sans-serif;font-size:100%;line-height:1.15;margin:0}button,input{overflow:visible}button,select{text-transform:none}[type=reset],[type=submit],button,html [type=button]{-webkit-appearance:button}[type=button]::-moz-focus-inner,[type=reset]::-moz-focus-inner,[type=submit]::-moz-focus-inner,button::-moz-focus-inner{border-style:none;padding:0}[type=button]:-moz-focusring,[type=reset]:-moz-focusring,[type=submit]:-moz-focusring,button:-moz-focusring{outline:1px dotted ButtonText}fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}legend{box-sizing:border-box;color:inherit;display:table;max-width:100%;padding:0;white-space:normal}progress{display:inline-block;vertical-align:baseline}textarea{overflow:auto}[type=checkbox],[type=radio]{box-sizing:border-box;padding:0}[type=number]::-webkit-inner-spin-button,[type=number]::-webkit-outer-spin-button{height:auto}[type=search]{-webkit-appearance:textfield;outline-offset:-2px}[type=search]::-webkit-search-cancel-button,[type=search]::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}details,menu{display:block}summary{display:list-item}canvas{display:inline-block}template{display:none}[hidden]{display:none}/*! Simple HttpErrorPages | MIT X11 License | https://github.com/AndiDittrich/HttpErrorPages */body,html{width:100%;height:100%;background-color:#21232a}body{color:#fff;text-align:center;text-shadow:0 2px 4px rgba(0,0,0,.5);padding:0;min-height:100%;-webkit-box-shadow:inset 0 0 100px rgba(0,0,0,.8);box-shadow:inset 0 0 100px rgba(0,0,0,.8);display:table;font-family:"Open Sans",Arial,sans-serif}h1{font-family:inherit;font-weight:500;line-height:1.1;color:inherit;font-size:36px}h1 small{font-size:68%;font-weight:400;line-height:1;color:#777}a{text-decoration:none;color:#fff;font-size:inherit;border-bottom:dotted 1px #707070}.lead{color:silver;font-size:21px;line-height:1.4}.cover{display:table-cell;vertical-align:middle;padding:0 20px}footer{position:fixed;width:100%;height:40px;left:0;bottom:0;color:#a0a0a0;font-size:14px}</style>
 </head>
 <body>
-    <div class="cover"><h1>${error} <small>401</small></h1><p class="lead">${error_description}<br />${error_uri}</p></div>
+    <div class="cover"><h1>${error} <small>401</small></h1><p class="lead">${
+        error_description ?? ''
+    }<br />${error_uri ?? ''}</p></div>
 </body>
 </html>
 `
@@ -28,7 +30,7 @@ export function unauthorized(
         statusDescription: 'Unauthorized',
         body: page,
         headers: {
-            'set-cookie': ['TOKEN', 'NONCE'].map((name) => ({
+            'set-cookie': ['TOKEN', 'REFRESH_TOKEN', 'NONCE'].map((name) => ({
                 key: 'Set-Cookie',
                 value: cookie.serialize(name, '', {
                     path: '/',


### PR DESCRIPTION
**Changes**
- Remove the `Secure` and `Http-Only` cookie attributes when clearing cookies 
- `offline_access` OpenID scope added to OIDC authorization request
- `REFRESH_TOKEN` stored in a cookie with `httpOnly` and expires in 7 days
- Added `/refresh-token` path, which uses the `REFRESH_TOKEN` cookie to issue a new `TOKEN` and `REFRESH_TOKEN` cookies 10mins before the `TOKEN` expires.
- `Same-Site: lax` cookie attribute is set to the `TOKEN` and `REFRESH_TOKEN` 