### PR TITLE
Await the handlers for the try...catch to succeed

### DIFF
--- a/.changeset/early-trainers-behave.md
+++ b/.changeset/early-trainers-behave.md
@@ -1,0 +1,5 @@
+---
+'@wanews/lambda-edge-openid-auth': patch
+---
+
+Await the async callback handlers since they throw errors which are caught and error responses are returned

--- a/libs/lambda-edge-openid-auth/src/lib/viewer-request.ts
+++ b/libs/lambda-edge-openid-auth/src/lib/viewer-request.ts
@@ -61,7 +61,7 @@ export const authenticateViewerRequest = async (
 
             if (request.uri.startsWith(config.callbackPath)) {
                 log.info('Callback from OIDC provider received')
-                return callbackHandler(
+                return await callbackHandler(
                     config,
                     idpConfig,
                     log,
@@ -80,7 +80,7 @@ export const authenticateViewerRequest = async (
 
             if (cookies && cookies.TOKEN) {
                 if (request.uri.startsWith(config.refreshPath)) {
-                    return refreshTokenHandler(
+                    return await refreshTokenHandler(
                         config,
                         idpConfig,
                         log,
@@ -90,7 +90,7 @@ export const authenticateViewerRequest = async (
                 }
 
                 log.info('Request received with TOKEN cookie. Validating.')
-                return validateTokenHandler(
+                return await validateTokenHandler(
                     config,
                     idpConfig,
                     log,


### PR DESCRIPTION
`callbackHandler` , `refreshTokenHandler` and `validateTokenHandler` run off async so an errors throw will not be caught. We need to await them